### PR TITLE
Move the blocking log operation to executor thread

### DIFF
--- a/core/main/java/com/codingchili/core/logging/LogMessage.java
+++ b/core/main/java/com/codingchili/core/logging/LogMessage.java
@@ -2,6 +2,9 @@ package com.codingchili.core.logging;
 
 import io.vertx.core.json.JsonObject;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static com.codingchili.core.configuration.CoreStrings.*;
 
 /**
@@ -10,6 +13,7 @@ import static com.codingchili.core.configuration.CoreStrings.*;
 public class LogMessage {
     private Logger logger;
     private JsonObject event;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     /**
      * Creates a new logging message. Constructor typically invoked indirectly
@@ -50,7 +54,9 @@ public class LogMessage {
      * @return the logger that was used to send the message.
      */
     public Logger send() {
-        logger.log(event);
+        executor.execute(() -> {
+            logger.log(event);
+        });
         return logger;
     }
 


### PR DESCRIPTION
Hi! :)
Apparently the logging module has a blocking call that is executed on event loop (detected by BlockHound).
<img width="925" alt="Screen Shot 2023-07-14 at 4 12 26 PM" src="https://github.com/codingchili/chili-core/assets/56495631/6158b6e4-98f0-472c-ba40-d4398c15262d">

This PR fixes the call so the pipeline remains reactive.
